### PR TITLE
Change the tunnel file to json

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,9 +49,10 @@ pub enum ConnectOptions {
 	/// Select the fastest ProtonVPN server.
 	Fastest,
 	/// Determine the country for fastest connect.
-	CountryCode { 
-		/// 2 letter country code, like US or IN. See [COUNTRY_CODES](static@crate::constants::COUNTRY_CODES) 
-		cc: String },
+	CountryCode {
+		/// 2 letter country code, like US or IN. See [COUNTRY_CODES](static@crate::constants::COUNTRY_CODES)
+		cc: String,
+	},
 	/// Connect to the fastest Secure-Core server.
 	SecureCore,
 	/// Connect to the fastest torrent server.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::env;
 
 lazy_static! {
-	/// Map from string country code to string country name 
+	/// Map from string country code to string country name
 	pub(crate) static ref COUNTRY_CODES: HashMap<String, String> = hmap! {
 		"BD" => "Bangladesh",
 		"BE" => "Belgium",
@@ -259,7 +259,7 @@ lazy_static! {
 	};
 }
 
-/// App name. Used to denote the binary's config directory (for dirs and confy), and then making api requests. 
+/// App name. Used to denote the binary's config directory (for dirs and confy), and then making api requests.
 pub const APP_NAME: &str = "protonvpn-rs";
 
 /// App version, taken using a clap macro. Used when making api requests
@@ -268,7 +268,7 @@ pub const VERSION: &str = structopt::clap::crate_version!();
 /// Filename for split tunnel ip masks. This file should be read/written by the app.  
 pub const SPLIT_TUNNEL_FILE: &str = "split_tunnel.txt";
 
-/// Name of the openvpn config file. Eventually we want to replace this with tempfiles. 
+/// Name of the openvpn config file. Eventually we want to replace this with tempfiles.
 pub const OVPN_FILE: &str = "connect.ovpn";
 
 /// Openvpn logs. Used for debugging

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,8 @@ use confy::load;
 use console::Term;
 use protonvpn::{cli::CliOptions, constants::APP_NAME, main as main_cli, vpn::util::Config};
 
-
 #[paw::main]
 fn main(args: CliOptions) -> Result<()> {
-	
 	// Stdio handle is passed through the entire program
 	let mut terminal = Term::buffered_stdout();
 

--- a/src/vpn.rs
+++ b/src/vpn.rs
@@ -80,7 +80,9 @@ where
 		ipv6_disabled: false,
 	};
 
-	let rendered = ovpn_conf.render().context("Rendering config file template failed")?;
+	let rendered = ovpn_conf
+		.render()
+		.context("Rendering config file template failed")?;
 	let mut out = BufWriter::new(output_file);
 	write!(out, "{}", rendered).context("Failed write")?;
 	Ok(())

--- a/src/vpn.rs
+++ b/src/vpn.rs
@@ -83,6 +83,7 @@ where
 		ipv6_disabled: false,
 	};
 
+	// TODO Use Template::render_into
 	let rendered = ovpn_conf
 		.render()
 		.context("Rendering config file template failed")?;

--- a/src/vpn.rs
+++ b/src/vpn.rs
@@ -30,9 +30,17 @@ struct OpenVpnConfig {
 }
 
 /// An IPv4 address and a netmask.
+#[derive(Serialize, Deserialize)]
 struct IpNm {
 	ip: Ipv4Addr,
+	#[serde(default = "IpNm::default_netmask")]
 	nm: Ipv4Addr,
+}
+
+impl IpNm {
+	fn default_netmask() -> Ipv4Addr {
+		"255.255.255.255".parse().unwrap()
+	}
 }
 
 /// Stores information about the current connection. Its purpose to prevent the passfile path from being dropped (upon drop the corresponding file is unlinked/deleted)

--- a/src/vpn.rs
+++ b/src/vpn.rs
@@ -55,7 +55,6 @@ fn create_openvpn_config<R, W>(
 	servers: &Vec<Ipv4Addr>,
 	protocol: &ConnectionProtocol,
 	ports: &Vec<usize>,
-	split_tunnel: &bool,
 	split_tunnel_file: Option<R>,
 	output_file: &mut W,
 ) -> Result<()>
@@ -75,7 +74,7 @@ where
 		openvpn_protocol: *protocol,
 		server_list: servers.clone(),
 		openvpn_ports: ports.clone(),
-		split: *split_tunnel,
+		split: split_tunnel_file.is_some(),
 		ip_nm_pairs,
 		// TODO check if ipv6 is actually disabled
 		ipv6_disabled: false,

--- a/src/vpn.rs
+++ b/src/vpn.rs
@@ -32,7 +32,7 @@ struct OpenVpnConfig {
 }
 
 /// An IPv4 address and a netmask.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 struct IpNm {
 	ip: Ipv4Addr,
 	#[serde(default = "IpNm::default_netmask")]
@@ -195,5 +195,19 @@ mod tests {
 		let output = Command::new("/usr/bin/cat").arg(&path).output()?;
 		assert!(output.status.success());
 		Ok(())
+	}
+
+	#[test]
+	fn test_ip_nm_serialize() {
+		use serde_json::from_str;
+		let expected = IpNm {
+			ip: "0.0.0.0".parse().unwrap(),
+			nm: IpNm::default_netmask(),
+		};
+
+		let stringy = r#"{"ip":"0.0.0.0"}"#;
+		let actual: IpNm = from_str(stringy).unwrap();
+
+		assert_eq!(expected, actual);
 	}
 }

--- a/src/vpn/util.rs
+++ b/src/vpn/util.rs
@@ -135,7 +135,7 @@ impl Default for MetaData {
 	}
 }
 
-/// Information about the current vpn connection. 
+/// Information about the current vpn connection.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ConnectionInfo {
 	pub(crate) server_id: String,


### PR DESCRIPTION
This change means we can just use serde instead a custom parser. Unfortunately, this is a breaking change with the official client protonvpn and with itself